### PR TITLE
Update schema.prisma.backup

### DIFF
--- a/prisma.backup/schema.prisma.backup
+++ b/prisma.backup/schema.prisma.backup
@@ -5,7 +5,6 @@ generator client {
 datasource db {
   provider = "postgresql"
   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
-  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
 }
 
 model Street {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.